### PR TITLE
Parent project update

### DIFF
--- a/app/src/me/openphoto/android/app/bitmapfun/util/ImageCache.java
+++ b/app/src/me/openphoto/android/app/bitmapfun/util/ImageCache.java
@@ -101,7 +101,8 @@ public class ImageCache {
                 activity.getSupportFragmentManager());
 
         // See if we already have an ImageCache stored in RetainFragment
-        ImageCache imageCache = (ImageCache) mRetainFragment.getObject();
+		ImageCache imageCache = (ImageCache) mRetainFragment
+				.getObject(cacheParams.uniqueName);
 
         // No existing ImageCache, create one and store it in RetainFragment
         if (imageCache == null) {
@@ -196,9 +197,20 @@ public class ImageCache {
     }
 
     public void clearCaches() {
-        mDiskCache.clearCache();
-        mMemoryCache.evictAll();
+		if (mDiskCache != null)
+		{
+			mDiskCache.clearCache();
+		}
+		clearMemoryCache();
     }
+
+	public void clearMemoryCache()
+	{
+		if (mMemoryCache != null)
+		{
+			mMemoryCache.evictAll();
+		}
+	}
 
     /**
      * A holder class that contains cache parameters.

--- a/app/src/me/openphoto/android/app/bitmapfun/util/ImageFetcher.java
+++ b/app/src/me/openphoto/android/app/bitmapfun/util/ImageFetcher.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.openphoto.android.app.bitmapfun.util;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import me.openphoto.android.app.BuildConfig;
+import me.openphoto.android.app.util.LoadingControl;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.util.Log;
+import android.widget.Toast;
+
+/**
+ * A simple subclass of {@link ImageResizer} that fetches and resizes images fetched from a URL.
+ */
+public class ImageFetcher extends ImageResizer {
+    private static final String TAG = "ImageFetcher";
+    private static final int HTTP_CACHE_SIZE = 10 * 1024 * 1024; // 10MB
+    public static final String HTTP_CACHE_DIR = "http";
+
+    /**
+	 * Initialize providing a target image width and height for the processing
+	 * images.
+	 * 
+	 * @param context
+	 * @param loadingControl
+	 * @param imageWidth
+	 * @param imageHeight
+	 */
+	public ImageFetcher(Context context, LoadingControl loadingControl,
+			int imageWidth, int imageHeight)
+	{
+		super(context, loadingControl, imageWidth, imageHeight);
+        init(context);
+    }
+
+    /**
+	 * Initialize providing a single target image size (used for both width and
+	 * height);
+	 * 
+	 * @param context
+	 * @param loadingControl
+	 * @param imageSize
+	 */
+	public ImageFetcher(Context context, LoadingControl loadingControl,
+			int imageSize)
+	{
+		super(context, loadingControl, imageSize);
+        init(context);
+    }
+
+    private void init(Context context) {
+        checkConnection(context);
+    }
+
+    /**
+     * Simple network connection check.
+     *
+     * @param context
+     */
+    private void checkConnection(Context context) {
+        final ConnectivityManager cm =
+                (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        final NetworkInfo networkInfo = cm.getActiveNetworkInfo();
+        if (networkInfo == null || !networkInfo.isConnectedOrConnecting()) {
+            Toast.makeText(context, "No network connection found.", Toast.LENGTH_LONG).show();
+            Log.e(TAG, "checkConnection - no connection found");
+        }
+    }
+
+    /**
+     * The main process method, which will be called by the ImageWorker in the AsyncTask background
+     * thread.
+     *
+     * @param data The data to load the bitmap, in this case, a regular http URL
+     * @return The downloaded and resized bitmap
+     */
+    private Bitmap processBitmap(String data) {
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "processBitmap - " + data);
+        }
+
+        // Download a bitmap, write it to a file
+        final File f = downloadBitmap(mContext, data);
+
+        if (f != null) {
+            // Return a sampled down version
+            return decodeSampledBitmapFromFile(f.toString(), mImageWidth, mImageHeight);
+        }
+
+        return null;
+    }
+
+    @Override
+    protected Bitmap processBitmap(Object data) {
+        return processBitmap(String.valueOf(data));
+    }
+
+    /**
+     * Download a bitmap from a URL, write it to a disk and return the File pointer. This
+     * implementation uses a simple disk cache.
+     *
+     * @param context The context to use
+     * @param urlString The URL to fetch
+     * @return A File pointing to the fetched bitmap
+     */
+    public static File downloadBitmap(Context context, String urlString) {
+        final File cacheDir = DiskLruCache.getDiskCacheDir(context, HTTP_CACHE_DIR);
+
+        final DiskLruCache cache =
+                DiskLruCache.openCache(context, cacheDir, HTTP_CACHE_SIZE);
+
+        final File cacheFile = new File(cache.createFilePath(urlString));
+
+        if (cache.containsKey(urlString)) {
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "downloadBitmap - found in http cache - " + urlString);
+            }
+            return cacheFile;
+        }
+
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "downloadBitmap - downloading - " + urlString);
+        }
+
+        Utils.disableConnectionReuseIfNecessary();
+        HttpURLConnection urlConnection = null;
+        BufferedOutputStream out = null;
+
+        try {
+            final URL url = new URL(urlString);
+            urlConnection = (HttpURLConnection) url.openConnection();
+            final InputStream in =
+                    new BufferedInputStream(urlConnection.getInputStream(), Utils.IO_BUFFER_SIZE);
+            out = new BufferedOutputStream(new FileOutputStream(cacheFile), Utils.IO_BUFFER_SIZE);
+
+            int b;
+            while ((b = in.read()) != -1) {
+                out.write(b);
+            }
+
+            return cacheFile;
+
+        } catch (final IOException e) {
+            Log.e(TAG, "Error in downloadBitmap - " + e);
+        } finally {
+            if (urlConnection != null) {
+                urlConnection.disconnect();
+            }
+            if (out != null) {
+                try {
+                    out.close();
+                } catch (final IOException e) {
+                    Log.e(TAG, "Error in downloadBitmap - " + e);
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/src/me/openphoto/android/app/bitmapfun/util/ImageFileSystemFetcher.java
+++ b/app/src/me/openphoto/android/app/bitmapfun/util/ImageFileSystemFetcher.java
@@ -4,6 +4,7 @@ import java.io.File;
 
 import me.openphoto.android.app.BuildConfig;
 import me.openphoto.android.app.util.CommonUtils;
+import me.openphoto.android.app.util.LoadingControl;
 import android.content.Context;
 import android.graphics.Bitmap;
 
@@ -11,18 +12,21 @@ public class ImageFileSystemFetcher extends ImageResizer
 {
 	private static final String TAG = ImageFileSystemFetcher.class
 			.getSimpleName();
+	
 	/**
 	 * Initialize providing a target image width and height for the processing
 	 * images.
 	 * 
 	 * @param context
+	 * @param loadingControl
 	 * @param imageWidth
 	 * @param imageHeight
 	 */
-	public ImageFileSystemFetcher(Context context, int imageWidth,
+	public ImageFileSystemFetcher(Context context,
+			LoadingControl loadingControl, int imageWidth,
 			int imageHeight)
 	{
-		super(context, imageWidth, imageHeight);
+		super(context, loadingControl, imageWidth, imageHeight);
 	}
 
 	/**
@@ -30,11 +34,13 @@ public class ImageFileSystemFetcher extends ImageResizer
 	 * height);
 	 * 
 	 * @param context
+	 * @param loadingControl
 	 * @param imageSize
 	 */
-	public ImageFileSystemFetcher(Context context, int imageSize)
+	public ImageFileSystemFetcher(Context context,
+			LoadingControl loadingControl, int imageSize)
 	{
-		super(context, imageSize);
+		super(context, loadingControl, imageSize);
 	}
 
 	/**

--- a/app/src/me/openphoto/android/app/bitmapfun/util/ImageResizer.java
+++ b/app/src/me/openphoto/android/app/bitmapfun/util/ImageResizer.java
@@ -18,6 +18,7 @@ package me.openphoto.android.app.bitmapfun.util;
 
 import me.openphoto.android.app.BuildConfig;
 import me.openphoto.android.app.util.CommonUtils;
+import me.openphoto.android.app.util.LoadingControl;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
@@ -35,25 +36,33 @@ public class ImageResizer extends ImageWorker {
     protected int mImageHeight;
 
     /**
-     * Initialize providing a single target image size (used for both width and height);
-     *
-     * @param context
-     * @param imageWidth
-     * @param imageHeight
-     */
-    public ImageResizer(Context context, int imageWidth, int imageHeight) {
-        super(context);
+	 * Initialize providing a single target image size (used for both width and
+	 * height);
+	 * 
+	 * @param context
+	 * @param loadingControl
+	 * @param imageWidth
+	 * @param imageHeight
+	 */
+	public ImageResizer(Context context, LoadingControl loadingControl,
+			int imageWidth, int imageHeight)
+	{
+		super(context, loadingControl);
         setImageSize(imageWidth, imageHeight);
     }
 
     /**
-     * Initialize providing a single target image size (used for both width and height);
-     *
-     * @param context
-     * @param imageSize
-     */
-    public ImageResizer(Context context, int imageSize) {
-        super(context);
+	 * Initialize providing a single target image size (used for both width and
+	 * height);
+	 * 
+	 * @param context
+	 * @param loadingControl
+	 * @param imageSize
+	 */
+	public ImageResizer(Context context, LoadingControl loadingControl,
+			int imageSize)
+	{
+		super(context, loadingControl);
         setImageSize(imageSize);
     }
 

--- a/app/src/me/openphoto/android/app/bitmapfun/util/RetainFragment.java
+++ b/app/src/me/openphoto/android/app/bitmapfun/util/RetainFragment.java
@@ -16,6 +16,9 @@
 
 package me.openphoto.android.app.bitmapfun.util;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -27,6 +30,7 @@ import android.support.v4.app.FragmentManager;
 public class RetainFragment extends Fragment {
     private static final String TAG = "RetainFragment";
     private Object mObject;
+	private Map<String, Object> map = new HashMap<String, Object>();
 
     /**
      * Empty constructor as per the Fragment documentation
@@ -80,4 +84,26 @@ public class RetainFragment extends Fragment {
         return mObject;
     }
 
+	public Object getObject(String key)
+	{
+		if (key == null)
+		{
+			return getObject();
+		} else
+		{
+			return map.get(key);
+		}
+	}
+
+	public void setObject(String key, Object object)
+	{
+		if (key == null)
+		{
+			setObject(object);
+		} else
+		{
+			map.put(key, object);
+		}
+	}
 }
+

--- a/app/src/me/openphoto/android/app/net/IOpenPhotoApi.java
+++ b/app/src/me/openphoto/android/app/net/IOpenPhotoApi.java
@@ -167,6 +167,23 @@ public interface IOpenPhotoApi {
             IllegalStateException, JSONException;
 
 	/**
+	 * Return Newest Photos to be used in the Home Screen
+	 * 
+	 * @param resize
+	 *            which sizes should be returned
+	 * @param paging
+	 *            paging for the newest hone screen
+	 * @return a list of photos to be displayed inthe home screen
+	 * @throws ClientProtocolException
+	 * @throws IOException
+	 * @throws IllegalStateException
+	 * @throws JSONException
+	 */
+	PhotosResponse getNewestPhotos(ReturnSizes resize, Paging paging)
+			throws ClientProtocolException, IOException,
+			IllegalStateException, JSONException;
+
+	/**
 	 * Return the photos by given SHA-1 hash
 	 * 
 	 * @param hash

--- a/app/src/me/openphoto/android/app/net/OpenPhotoApi.java
+++ b/app/src/me/openphoto/android/app/net/OpenPhotoApi.java
@@ -207,30 +207,45 @@ public class OpenPhotoApi extends ApiBase implements IOpenPhotoApi {
     public PhotosResponse getNewestPhotos(Paging paging) throws ClientProtocolException,
             IOException,
             IllegalStateException, JSONException {
-        ApiRequest request = new ApiRequest(ApiRequest.GET, "/photos/list.json");
-        request.addParameter("returnSizes", "700x650xCR");
-        request.addParameter("sortBy", "dateUploaded,DESC");
-
-        if (paging != null) {
-            if (paging.hasPage()) {
-                request.addParameter("page", Integer.toString(paging.getPage()));
-            }
-            if (paging.hasPageSize()) {
-                request.addParameter("pageSize",
-                        Integer.toString(paging.getPageSize()));
-            }
-        }
-        ApiResponse response = execute(request);
-        String result = response.getContentAsString();
-        return new PhotosResponse(new JSONObject(result));
+		return getNewestPhotos(null, paging);
     }
 
-    /**
-     * ONLY FOR TESTING! Will make the class return the given Mock when
-     * accessing createInstance(..)
-     * 
-     * @param mock Mock to be used for OpenPhotoApi
-     */
+	@Override
+	public PhotosResponse getNewestPhotos(ReturnSizes returnSize, Paging paging)
+			throws ClientProtocolException, IOException, IllegalStateException,
+			JSONException
+	{
+		ApiRequest request = new ApiRequest(ApiRequest.GET, "/photos/list.json");
+		if (returnSize != null)
+		{
+			request.addParameter("returnSizes", returnSize.toString());
+		}
+		request.addParameter("sortBy", "dateUploaded,DESC");
+
+		if (paging != null)
+		{
+			if (paging.hasPage())
+			{
+				request.addParameter("page", Integer.toString(paging.getPage()));
+			}
+			if (paging.hasPageSize())
+			{
+				request.addParameter("pageSize",
+						Integer.toString(paging.getPageSize()));
+			}
+		}
+		ApiResponse response = execute(request);
+		String result = response.getContentAsString();
+		return new PhotosResponse(new JSONObject(result));
+	}
+
+	/**
+	 * ONLY FOR TESTING! Will make the class return the given Mock when
+	 * accessing createInstance(..)
+	 * 
+	 * @param mock
+	 *            Mock to be used for OpenPhotoApi
+	 */
     public static void injectMock(IOpenPhotoApi mock) {
         OpenPhotoApi.sMock = mock;
     }


### PR DESCRIPTION
- changed ImageWorker in the HomeFragmetn to the one from the bitmapfun
  library with the more efficient caching
- moved image worker creation from onCreate to the onCreateView in the
  SyncImageSelectionFragment
- added image cache clearing to the onDestroyView method fo the
  SyncImageSelectionFragment
- added toString method to the ImageData internal class of the
  SyncImageSelectionFragment which fixes thumb caching file name
- added onCancel handling to the InitTask of SyncImageSelectionFragment
- added possibility to have few image cache instances depend on unique
  name in the ImageCache
- added clearMemoryCache method to the ImageCache
- added ImageFetcher from the bitmapfun
- added loadingControl constructor parameter to ImageResizer,
  ImageWorker, ImageFileSystemFetcher
- added loadingControl support to the BitmapWorkerTask of the
  ImageWorker
- added possibility to store more objects by unique key in the
  RetainFragment
- added new variation of getNewestPhotos to the IOpenPhotoApi
