### PR TITLE
Parent project update

### DIFF
--- a/app/src/me/openphoto/android/app/OpenPhotoApplication.java
+++ b/app/src/me/openphoto/android/app/OpenPhotoApplication.java
@@ -3,9 +3,9 @@ package me.openphoto.android.app;
 
 import me.openphoto.android.app.facebook.FacebookProvider;
 import me.openphoto.android.app.util.GuiUtils;
-import android.app.Application;
 import android.content.Context;
 
+import com.WazaBe.HoloEverywhere.app.Application;
 import com.bugsense.trace.BugSenseHandler;
 import com.facebook.android.R;
 

--- a/app/src/me/openphoto/android/app/Preferences.java
+++ b/app/src/me/openphoto/android/app/Preferences.java
@@ -12,11 +12,12 @@ import android.content.SharedPreferences;
 
 public class Preferences {
     public final static int PREFERENCES_MODE = Context.MODE_MULTI_PROCESS;
+    public final static String PREFERENCES_NAME = "default";
 
     public static SharedPreferences getDefaultSharedPreferences(Context context)
     {
         return OpenPhotoApplication.getContext().getSharedPreferences(
-                "default",
+                PREFERENCES_NAME,
                 PREFERENCES_MODE);
     }
 
@@ -34,6 +35,12 @@ public class Preferences {
                         context.getResources().getBoolean(R.bool.setting_autoupload_on_default));
     }
 
+    public static void setAutoUploadActive(Context context, boolean active)
+    {
+        getDefaultSharedPreferences(context).edit()
+                .putBoolean(context.getString(R.string.setting_autoupload_on_key), active).commit();
+    }
+
     public static boolean isWiFiOnlyUploadActive(Context context)
     {
         return getDefaultSharedPreferences(context)
@@ -41,6 +48,13 @@ public class Preferences {
                         context.getString(R.string.setting_wifi_only_upload_on_key),
                         context.getResources().getBoolean(
                                 R.bool.setting_wifi_only_upload_on_default));
+    }
+
+    public static void setWiFiOnlyUploadActive(Context context, boolean active)
+    {
+        getDefaultSharedPreferences(context).edit()
+                .putBoolean(context.getString(R.string.setting_wifi_only_upload_on_key), active)
+                .commit();
     }
 
     public static String getAutoUploadTag(Context context) {

--- a/app/src/me/openphoto/android/app/SettingsCommon.java
+++ b/app/src/me/openphoto/android/app/SettingsCommon.java
@@ -6,10 +6,12 @@ import me.openphoto.android.app.facebook.FacebookSessionEvents;
 import me.openphoto.android.app.facebook.FacebookSessionEvents.LogoutListener;
 import me.openphoto.android.app.facebook.FacebookUtils;
 import me.openphoto.android.app.provider.UploadsUtils;
+import me.openphoto.android.app.util.CommonUtils;
 import android.app.Activity;
 import android.content.DialogInterface;
 
 import com.WazaBe.HoloEverywhere.app.AlertDialog;
+import com.WazaBe.HoloEverywhere.preference.CheckBoxPreference;
 import com.WazaBe.HoloEverywhere.preference.EditTextPreference;
 import com.WazaBe.HoloEverywhere.preference.Preference;
 import com.WazaBe.HoloEverywhere.preference.Preference.OnPreferenceChangeListener;
@@ -26,6 +28,8 @@ public class SettingsCommon implements
     Preference mSyncClearPreference;
     PreferenceCategory loginCategory;
     Preference mServerUrl;
+    CheckBoxPreference autoUploadActive;
+    CheckBoxPreference wiFiOnlyUpload;
 
     public SettingsCommon(Activity activity)
     {
@@ -202,6 +206,36 @@ public class SettingsCommon implements
                         return true;
                     }
                 });
+    }
+
+    public void setAutoUploadActive(CheckBoxPreference autoUploadActive) {
+        this.autoUploadActive = autoUploadActive;
+        autoUploadActive.setOnPreferenceChangeListener(null);
+        autoUploadActive.setChecked(Preferences.isAutoUploadActive(activity));
+        autoUploadActive.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                CommonUtils.debug(TAG, "AutoUpload preference changed. New value is:" + newValue);
+                Preferences.setAutoUploadActive(activity, (Boolean) newValue);
+                return true;
+            }
+        });
+    }
+
+    public void setWiFiOnlyUpload(CheckBoxPreference wiFiOnlyUpload) {
+        this.wiFiOnlyUpload = wiFiOnlyUpload;
+        wiFiOnlyUpload.setOnPreferenceChangeListener(null);
+        wiFiOnlyUpload.setChecked(Preferences.isWiFiOnlyUploadActive(activity));
+        wiFiOnlyUpload.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                CommonUtils.debug(TAG, "WiFi only preference changed. New value is:" + newValue);
+                Preferences.setWiFiOnlyUploadActive(activity, (Boolean) newValue);
+                return true;
+            }
+        });
     }
 
 }

--- a/app/src/me/openphoto/android/app/SettingsFragment.java
+++ b/app/src/me/openphoto/android/app/SettingsFragment.java
@@ -3,6 +3,7 @@ package me.openphoto.android.app;
 
 import android.os.Bundle;
 
+import com.WazaBe.HoloEverywhere.preference.CheckBoxPreference;
 import com.WazaBe.HoloEverywhere.preference.PreferenceCategory;
 import com.WazaBe.HoloEverywhere.sherlock.SPreferenceFragment;
 
@@ -17,6 +18,8 @@ public class SettingsFragment extends SPreferenceFragment
     public void onCreate(Bundle savedInstanceState)
     {
         super.onCreate(savedInstanceState);
+        getPreferenceManager().setSharedPreferencesName(Preferences.PREFERENCES_NAME);
+        getPreferenceManager().setSharedPreferencesMode(Preferences.PREFERENCES_MODE);
         addPreferencesFromResource(R.xml.settings);
 
         settingsCommon = new SettingsCommon(getActivity());
@@ -31,6 +34,10 @@ public class SettingsFragment extends SPreferenceFragment
                 .setServerUrl(findPreference(getString(R.string.setting_account_server_key)));
         settingsCommon
                 .setSyncClearPreference(findPreference(getString(R.string.setting_sync_clear_key)));
+        settingsCommon
+                .setAutoUploadActive((CheckBoxPreference) findPreference(getString(R.string.setting_autoupload_on_key)));
+        settingsCommon
+                .setWiFiOnlyUpload((CheckBoxPreference) findPreference(getString(R.string.setting_wifi_only_upload_on_key)));
     }
 
     @Override


### PR DESCRIPTION
- Preferences: added new methods setAutoUploadActive and
  setWiFiOnlyUploadActive
- SettingsCommon: added new fields and setting methods for
  autoUploadActive and wiFiOnlyUpload preferences
- SettingsFragment: specified default name and mode for the preference
  manager
- SettingsFragment: setting autoUploadActive and wiFiOnlyUpload
  preference references to the settingsCommon
