### PR TITLE
Use different string resource for the hint for the Title field in the Upload activity.

### DIFF
--- a/app/res/layout/activity_upload.xml
+++ b/app/res/layout/activity_upload.xml
@@ -54,7 +54,7 @@
                         android:id="@+id/edit_title"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:hint="@string/upload_title"
+                        android:hint="@string/upload_title_hint"
                         android:inputType="textCapWords" />
 
                     <EditText

--- a/app/res/layout/fragment_sync_upload_settings.xml
+++ b/app/res/layout/fragment_sync_upload_settings.xml
@@ -18,7 +18,7 @@
 			android:layout_height="wrap_content" android:orientation="vertical">
 			<EditText android:id="@+id/edit_title" android:layout_width="match_parent"
 				android:layout_height="wrap_content" android:ems="10"
-				android:hint="@string/upload_title" android:inputType="textCapWords">
+				android:hint="@string/upload_title_hint" android:inputType="textCapWords">
 			</EditText>
 			<EditText android:id="@+id/edit_tags" android:layout_width="match_parent"
 				android:layout_height="wrap_content" android:ems="10"

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -71,6 +71,7 @@
     <string name="upload_camera_option">Camera</string>
     <string name="upload_gallery_option">Gallery</string>
     <string name="upload_title">Upload</string>
+    <string name="upload_title_hint">Title</string>
     <string name="upload_tags">Tags</string>
     <string name="upload_select_tags">Select Tags</string>
     <string name="upload_select_tags_finish">Finish</string>


### PR DESCRIPTION
Currently the title of the Upload Activity itself and the hint for the title field in the upload activity refer to the same resource, upload_title.

Fixes #217
