### PR TITLE
Parent project update

### DIFF
--- a/app/src/me/openphoto/android/app/SyncFragment.java
+++ b/app/src/me/openphoto/android/app/SyncFragment.java
@@ -1,6 +1,7 @@
 
 package me.openphoto.android.app;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import me.openphoto.android.app.SyncImageSelectionFragment.NextStepFlow;
@@ -241,13 +242,12 @@ public class SyncFragment extends CommonFragment implements NextStepFlow,
     }
 
     @Override
-    public List<String> getSelectedFileNames()
+    public ArrayList<String> getSelectedFileNames()
     {
         return firstStepFragment.getSelectedFileNames();
     }
 
-    @Override
-    public void uploadStarted(List<String> processedFileNames)
+    public void syncStarted(List<String> processedFileNames)
     {
         // detachActiveFragment();
         firstStepFragment.clear();

--- a/app/src/me/openphoto/android/app/SyncImageSelectionFragment.java
+++ b/app/src/me/openphoto/android/app/SyncImageSelectionFragment.java
@@ -245,7 +245,7 @@ public class SyncImageSelectionFragment extends CommonRefreshableFragmentWithIma
         mImageWorker.setLoadingImage(R.drawable.empty_photo);
 
         mImageWorker.setImageCache(ImageCache.findOrCreateCache(getActivity(),
-                ImageCache.LOCAL_THUMBS_CACHE_DIR, false));
+                ImageCache.LOCAL_THUMBS_CACHE_DIR, 500, false));
     }
 
     protected void switchUploadState(boolean isChecked)
@@ -338,14 +338,14 @@ public class SyncImageSelectionFragment extends CommonRefreshableFragmentWithIma
         selectionController.clearSelection();
     }
 
-    public List<String> getSelectedFileNames()
+    public ArrayList<String> getSelectedFileNames()
     {
+        long start = System.currentTimeMillis();
+        ArrayList<String> result = new ArrayList<String>();
         if (customImageWorkerAdapter == null)
         {
-            return Collections.emptyList();
+            return result;
         }
-        long start = System.currentTimeMillis();
-        List<String> result = new ArrayList<String>();
         for (int i = 0, size = customImageWorkerAdapter.getSize(); i < size; i++)
         {
             ImageData imageData = (ImageData) customImageWorkerAdapter.getItem(i);

--- a/app/src/me/openphoto/android/app/SyncUploadFragment.java
+++ b/app/src/me/openphoto/android/app/SyncUploadFragment.java
@@ -2,7 +2,7 @@
 package me.openphoto.android.app;
 
 import java.io.File;
-import java.util.List;
+import java.util.ArrayList;
 
 import me.openphoto.android.app.common.CommonFragment;
 import me.openphoto.android.app.facebook.FacebookUtils;
@@ -13,6 +13,7 @@ import me.openphoto.android.app.twitter.TwitterUtils;
 import me.openphoto.android.app.util.GuiUtils;
 import me.openphoto.android.app.util.LoadingControl;
 import me.openphoto.android.app.util.ProgressDialogLoadingControl;
+import me.openphoto.android.app.util.SyncUtils;
 import me.openphoto.android.app.util.TrackerUtils;
 import me.openphoto.android.app.util.concurrent.AsyncTaskEx;
 
@@ -183,16 +184,14 @@ public class SyncUploadFragment extends CommonFragment
     {
         void activatePreviousStep();
 
-        List<String> getSelectedFileNames();
-
-        void uploadStarted(List<String> processedFileNames);
+        ArrayList<String> getSelectedFileNames();
     }
 
     private class UploadInitTask extends
             AsyncTaskEx<Void, Void, Boolean>
     {
 
-        private List<String> selectedFiles;
+        private ArrayList<String> selectedFiles;
 
         @Override
         protected Boolean doInBackground(Void... params)
@@ -200,7 +199,7 @@ public class SyncUploadFragment extends CommonFragment
             try
             {
                 UploadsProviderAccessor uploads = new UploadsProviderAccessor(
-                        getActivity());
+                        OpenPhotoApplication.getContext());
                 UploadMetaData metaData = new UploadMetaData();
                 metaData.setTitle(editTitle
                         .getText().toString());
@@ -246,7 +245,7 @@ public class SyncUploadFragment extends CommonFragment
             if (result.booleanValue())
             {
                 GuiUtils.alert(R.string.uploading_in_background);
-                getPreviousStepFlow().uploadStarted(selectedFiles);
+                SyncUtils.sendSyncStartedBroadcast(selectedFiles);
             }
         }
 

--- a/app/src/me/openphoto/android/app/bitmapfun/util/ImageCache.java
+++ b/app/src/me/openphoto/android/app/bitmapfun/util/ImageCache.java
@@ -92,7 +92,8 @@ public class ImageCache {
      */
     public static ImageCache findOrCreateCache(
             final FragmentActivity activity, final String uniqueName) {
-        return findOrCreateCache(activity, uniqueName, DEFAULT_CLEAR_DISK_CACHE_ON_START);
+        return findOrCreateCache(activity, uniqueName, DEFAULT_DISK_CACHE_MAX_ITEM_SIZE,
+                DEFAULT_CLEAR_DISK_CACHE_ON_START);
     }
 
     /**
@@ -102,6 +103,8 @@ public class ImageCache {
      * 
      * @param activity The calling {@link FragmentActivity}
      * @param uniqueName A unique name to append to the cache directory
+     * @param diskCacheMaxItemSize max item size for the disk cache
+     * @param clearDiskCacheOnStart whether to clear disk cache on start
      * @return An existing retained ImageCache object or a new one if one did
      *         not exist.
      * @param clearDiskCacheOnStart whether to clear disk cache on start
@@ -109,6 +112,7 @@ public class ImageCache {
      */
     public static ImageCache findOrCreateCache(
             final FragmentActivity activity, final String uniqueName,
+            final int diskCacheMaxItemSize,
             boolean clearDiskCacheOnStart) {
         ImageCacheParams params = new ImageCacheParams(uniqueName);
         // Get memory class of this device, exceeding this amount will throw an
@@ -119,6 +123,7 @@ public class ImageCache {
         // Use 1/8th of the available memory for this memory cache.
         params.memCacheSize = 1024 * 1024 * memClass / 8;
         params.clearDiskCacheOnStart = clearDiskCacheOnStart;
+        params.diskCacheMaxItemSize = diskCacheMaxItemSize;
         CommonUtils.debug(TAG, "Calculated memory cache size: " + params.memCacheSize);
 
         return findOrCreateCache(activity, params);

--- a/app/src/me/openphoto/android/app/provider/UploadsUtils.java
+++ b/app/src/me/openphoto/android/app/provider/UploadsUtils.java
@@ -28,9 +28,15 @@ public class UploadsUtils
             @Override
             public void onReceive(Context context, Intent intent)
             {
-                CommonUtils.debug(TAG,
-                        "Received uploads cleared broadcast message");
-                handler.uploadsCleared();
+                try
+                {
+                    CommonUtils.debug(TAG,
+                            "Received uploads cleared broadcast message");
+                    handler.uploadsCleared();
+                } catch (Exception ex)
+                {
+                    GuiUtils.error(TAG, ex);
+                }
             }
         };
         activity.registerReceiver(br, new IntentFilter(BROADCAST_ACTION));

--- a/app/src/me/openphoto/android/app/service/UploaderServiceUtils.java
+++ b/app/src/me/openphoto/android/app/service/UploaderServiceUtils.java
@@ -3,6 +3,7 @@ package me.openphoto.android.app.service;
 
 import me.openphoto.android.app.OpenPhotoApplication;
 import me.openphoto.android.app.util.CommonUtils;
+import me.openphoto.android.app.util.GuiUtils;
 import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -26,9 +27,15 @@ public class UploaderServiceUtils {
             @Override
             public void onReceive(Context context, Intent intent)
             {
-                CommonUtils.debug(TAG,
-                        "Received photo uploaded broadcast message");
-                handler.photoUploaded();
+                try
+                {
+                    CommonUtils.debug(TAG,
+                            "Received photo uploaded broadcast message");
+                    handler.photoUploaded();
+                } catch (Exception ex)
+                {
+                    GuiUtils.error(TAG, ex);
+                }
             }
         };
         activity.registerReceiver(br, new IntentFilter(PHOTO_UPLOADED_ACTION));

--- a/app/src/me/openphoto/android/app/util/SyncUtils.java
+++ b/app/src/me/openphoto/android/app/util/SyncUtils.java
@@ -1,0 +1,79 @@
+
+package me.openphoto.android.app.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import me.openphoto.android.app.OpenPhotoApplication;
+
+import org.holoeverywhere.app.Activity;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+
+/**
+ * Sync action utils
+ * 
+ * @author Eugene Popovich
+ */
+public class SyncUtils {
+    public static String SYNC_STARTED_ACTION = "me.openphoto.SYNC_STARTED";
+    public static String SYNC_FILE_NAMES = "SYNC_FILE_NAMES";
+
+    /**
+     * Get and register the sync started broadcast receiver
+     * 
+     * @param TAG
+     * @param handler
+     * @param activity
+     * @return
+     */
+    public static BroadcastReceiver getAndRegisterOnSyncStartedActionBroadcastReceiver(
+            final String TAG,
+            final SyncStartedHandler handler,
+            final Activity activity)
+    {
+        BroadcastReceiver br = new BroadcastReceiver()
+        {
+
+            @Override
+            public void onReceive(Context context, Intent intent)
+            {
+                try
+                {
+                    CommonUtils.debug(TAG,
+                            "Received sync started broadcast message");
+                    handler.syncStarted(intent.getStringArrayListExtra(SYNC_FILE_NAMES));
+                } catch (Exception ex)
+                {
+                    GuiUtils.error(TAG, ex);
+                }
+            }
+        };
+        activity.registerReceiver(br, new IntentFilter(SYNC_STARTED_ACTION));
+        return br;
+    }
+
+    /**
+     * Send the sync started broadcast message with the processedFileNames as
+     * the parameter
+     * 
+     * @param processedFileNames
+     */
+    public static void sendSyncStartedBroadcast(ArrayList<String> processedFileNames)
+    {
+        Intent intent = new Intent(SYNC_STARTED_ACTION);
+        intent.putStringArrayListExtra(SYNC_FILE_NAMES, processedFileNames);
+        OpenPhotoApplication.getContext().sendBroadcast(intent);
+    }
+
+    /**
+     * The sync starter handler interface
+     */
+    public static interface SyncStartedHandler
+    {
+        void syncStarted(List<String> processedFileNames);
+    }
+}


### PR DESCRIPTION
- MainActivity: added separate variable to handle whether action bar
  navigation mode should be initiated
- MainActivity: added sync started broadcast receiver
- MainActivity: added reseting instanceSaved variable onResume action
- MainActivity.TabListener: added fragment getView null check to avoid
  NPE in the onTabUnselected action. Also moved fragment detaching after
  the virtual keyboard hiding code (issue #263)
- MainActivity: added instanceSaved check to the syncStarted method to
  do not select tab if activity was suspended (otherwise it crashes
  application)
- MainActivity: now it implements SyncStartedHandler and added
  syncStarted implementation
- SyncFragment, SyncImageSelectionFragment: getSelectedFileNames now
  returns ArrayList insted of List because List can't be saved as
  parcelable
- SyncFragment: renamed uploadStarted to syncStarted. Also removed
  Override annotation such as it is not actual anymore
- SyncImageSelectionFragment: extended disk image cache max item size
  capacity from default 64 to 500
- SyncUploadFragment.PreviousStepFlow: removed uploadStarted method
- SyncUploadFragment.UploadInitTask: UploadsProviderAccessor now
  initiated with application context such as getActivity() may return null
  in some cases
- SyncUploadFragment.UploadInitTask: onPostExecute now sends broadcast
  even when sync is started instead of calling method from
  PreviousStepFlow implementor. This gives better results if during upload
  processing orientation is changed. But not in 100% of cases
- ImageCache: added additional parameter to findOrCreateCache method
  variation diskCacheMaxItemSize.
- UploadUtils: added exception handling to the
  UploadsClearedHandler.uploadsCleared call in the broadcast receiver
- UploaderServiceUtils: added exception handling to the
  PhotoUploadedHandler.photoUploaded call in the broadcast receiver
- SyncUtils: added
