### PR TITLE
Parent project update

### DIFF
--- a/app/src/com/trovebox/android/app/service/NewPhotoObserver.java
+++ b/app/src/com/trovebox/android/app/service/NewPhotoObserver.java
@@ -76,12 +76,18 @@ public class NewPhotoObserver extends FileObserver {
     private boolean checkLimits()
     {
         AccountLimitUtils.updateLimitInformationCache();
-        int remaining = Preferences.getRemainingUploadingLimit();
-        UploadsProviderAccessor uploads = new UploadsProviderAccessor(
-                TroveboxApplication.getContext());
-        int pending = uploads.getPendingUploadsCount();
-        boolean result = remaining - pending >= 1;
-        return result;
+        if (Preferences.isProUser())
+        {
+            return true;
+        } else
+        {
+            int remaining = Preferences.getRemainingUploadingLimit();
+            UploadsProviderAccessor uploads = new UploadsProviderAccessor(
+                    TroveboxApplication.getContext());
+            int pending = uploads.getPendingUploadsCount();
+            boolean result = remaining - pending >= 1;
+            return result;
+        }
     }
 
     /**


### PR DESCRIPTION
- NewPhotoObserver: added whether user is pro check to the checkLimits
  method ignoring remaining upload limit information if it is
